### PR TITLE
- Added fix for notification BAD_ACCESS

### DIFF
--- a/SatelliteStore.m
+++ b/SatelliteStore.m
@@ -154,6 +154,9 @@ static SatelliteStore * _shoppingCenter = nil;
     // remove the transaction from the payment queue.
     [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
     
+    //Remove the transaction observer so there is no chance to send notification to nil object
+    [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
+    
     // Completion
     if (self.purchaseCompletion) {
         self.purchaseCompletion(wasSuccessful);


### PR DESCRIPTION
Also, take a quick look at 

``` objc
- (void)failedTransaction:(SKPaymentTransaction *)transaction
{
    if (transaction.error.code != SKErrorPaymentCancelled)
    {
        // error!
        [self finishTransaction:transaction wasSuccessful:NO];
    }
    else
    {
        // this is fine, the user just cancelled, so don’t notify
        [self finishTransaction:transaction wasSuccessful:NO];
        [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
    }
}
```

I think the line <code>[[SKPaymentQueue defaultQueue] finishTransaction:transaction];</code> can be removed as it gets hit in the method called in the line before it. I didn't want to take it out in this pull request in case there was something I didn't know and it needs to be hit twice.

-Matt
